### PR TITLE
Add IQB rules that are low risk

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,14 @@ module.exports = {
     extends: [
         'standard-with-typescript'
     ],
-    rules: {}
+    rules: {
+        '@typescript-eslint/ban-types': 'error',
+        '@typescript-eslint/explicit-module-boundary-types': 'error',
+        '@typescript-eslint/no-explicit-any': 'error',
+        'consistent-return': 'error',
+        'no-empty-function': 'error',
+        'no-func-assign': 'error',
+        'no-shadow': 'error',
+        'no-unused-labels': 'error'
+    }
 }


### PR DESCRIPTION
It's [been decided](https://docs.google.com/document/d/14djw08HcGhply2KoqrKS-__fBvfuf2ry1VXncTlQedE/edit?ts=6041ea71#) that we resolve the misalignment of eslint style rules between IQB and SEM.

We've [completed analysis](https://docs.google.com/spreadsheets/d/1h3F6Ro1QSAmCYi1GRS0NRgTPes39zuZhTrycGarmCgY/edit#gid=0) of the rules that differ between the IQB and StandardJS (which SEM uses).

Using the Sococo code base to validate, these rules are low impact, have few false positives, and are being added in this pull request:
* @typescript-eslint/ban-types
* @typescript-eslint/explicit-module-boundary-types
* @typescript-eslint/no-explicit-any
* consistent-return
* no-empty-function
* no-func-assign
* no-shadow
* no-unused-labels

These rules are not added because of the risk of false positives or limited value:
* no-console
* no-magic-numbers
* no-else-return