### PR TITLE
fix(rules): disables JS rule and enable TS equivalent

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,11 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/no-explicit-any': 'error',
         'consistent-return': 'error',
-        'no-empty-function': 'error',
+        'no-empty-function': 'off',
+        '@typescript-eslint/no-empty-function': 'error',
         'no-func-assign': 'error',
-        'no-shadow': 'error',
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 'error',
         'no-unused-labels': 'error'
     }
 }


### PR DESCRIPTION
The Typescript rules are expected to replace their Javascript equivalents.
We have some Javascript versions enabled instead of the Typescript ones.