### PR TITLE
Avoid unnecessary 'as unknown as X' cast when creating mocks in unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,5 +13,15 @@ module.exports = {
         'no-shadow': 'off',
         '@typescript-eslint/no-shadow': 'error',
         'no-unused-labels': 'error'
-    }
+    },
+    overrides: [
+        // unit tests
+        {
+            files: [ '**/*.spec.*', '**/*.test.*' ],
+            rules: {
+                // unit tests need to create mocks easily, relax objectLiteralTypeAssertions
+                '@typescript-eslint/consistent-type-assertions': [ 'error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' } ]
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Relax the consistent-type-assertions rule for unit tests.
It forces us to do `{} as unknown as X` when creating mocks, which is just unnecessary and unintuitive.