### PR TITLE
allow empty functions in unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ module.exports = {
         {
             files: [ '**/*.spec.*', '**/*.test.*' ],
             rules: {
-                // unit tests need to create mocks easily, relax objectLiteralTypeAssertions
-                '@typescript-eslint/consistent-type-assertions': [ 'error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' } ]
+                // unit tests need to create mocks easily, relax rules that make this difficult
+                '@typescript-eslint/consistent-type-assertions': [ 'error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' } ],
+                '@typescript-eslint/no-empty-function': 'off'
             }
         }
     ]


### PR DESCRIPTION
Allow empty functions in unit tests, because they're used extensively in creating function mocks.

Example:
![2021-07-13 at 1 06 AM](https://user-images.githubusercontent.com/761257/125292418-8f9cdc00-e376-11eb-84e0-ee091a737f33.png)

Example 2:
![2021-07-13 at 1 07 AM](https://user-images.githubusercontent.com/761257/125292554-ae02d780-e376-11eb-94f7-109f2b35918e.png)
