### PR TITLE
make "var" an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
         'standard-with-typescript'
     ],
     rules: {
+        'no-var': 'error',
         '@typescript-eslint/ban-types': 'error',
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/no-explicit-any': 'error',


### PR DESCRIPTION
ECMAScript 6 allows programmers to create variables with block scope instead of function scope using the let and const keywords.

StandardJS only warns about the use of "var" to maintain compatibility with pre-ES6 environments (Node 12). This is not relevant to us as all our code should now be on Node 14. We can therefore enforce the use of "var".

This was highlighted from DevCoach so we're aligning on the rule.
