### PR TITLE
no-console for frontend

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ module.exports = {
                 // unit tests need to create mocks easily, relax objectLiteralTypeAssertions
                 '@typescript-eslint/consistent-type-assertions': [ 'error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' } ]
             }
+        },
+        {
+            "files": ["**/frontend/*.js", "**/frontend/*.ts"],
+            "rules": {
+                "no-console": "error"
+            }
         }
     ]
 }

--- a/index.js
+++ b/index.js
@@ -22,11 +22,11 @@ module.exports = {
                 // unit tests need to create mocks easily, relax objectLiteralTypeAssertions
                 '@typescript-eslint/consistent-type-assertions': [ 'error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' } ]
             }
-        },
-        {
-            "files": ["**/frontend/*.js", "**/frontend/*.ts"],
-            "rules": {
-                "no-console": "error"
+        }, {
+            // we need no-console to run on frontend 
+            files: ['**/frontend/*.js', '**/frontend/*.ts'],
+            rules: {
+                'no-console': 'error'
             }
         }
     ]

--- a/index.js
+++ b/index.js
@@ -15,15 +15,15 @@ module.exports = {
         'no-unused-labels': 'error'
     },
     overrides: [
-        // unit tests
         {
+            // unit tests
             files: [ '**/*.spec.*', '**/*.test.*' ],
             rules: {
                 // unit tests need to create mocks easily, relax objectLiteralTypeAssertions
                 '@typescript-eslint/consistent-type-assertions': [ 'error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow' } ]
             }
         }, {
-            // we need no-console to run on frontend 
+            // no-console to run on frontend 
             files: ['**/frontend/*.js', '**/frontend/*.ts'],
             rules: {
                 'no-console': 'error'

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
             }
         }, {
             // no-console to run on frontend 
-            files: ['**/frontend/*.js', '**/frontend/*.ts'],
+            files: ['**/frontend/**/*.js', '**/frontend/**/*.ts'],
             rules: {
                 'no-console': 'error'
             }


### PR DESCRIPTION
This introduces the no-console rule, because it's being flagged in DevCoach.

We have enabled this for frontend paths only, because the rule is recommended for browser code and not for Node.js code:
"In JavaScript that is designed to be executed in the browser, it's considered a best practice to avoid using methods on console" ([ref](https://eslint.org/docs/rules/no-console)), and "If you are developing for Node.js then you most likely do not want this rule enabled." ([ref](https://eslint.org/docs/rules/no-console#when-not-to-use-it))