### PR TITLE
add max-depth rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ module.exports = {
         'no-shadow': 'off',
         '@typescript-eslint/no-shadow': 'error',
         'no-unused-labels': 'error',
-        'no-console': 'error'
+        'no-console': 'error',
+        'max-depth': 'error'
     },
     overrides: [
         {


### PR DESCRIPTION
We're removing CodeClimate, the only rule we still want is [max-depth](https://eslint.org/docs/rules/max-depth), so adding it as part of ESLint. The default depth is 4.